### PR TITLE
Remove Lighthouse checks

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,33 +9,6 @@ on:
       - "!master" # but excludes master
 
 jobs:
-  lighthouse-check:
-    runs-on: ubuntu-latest
-    steps:
-      # checkout the repo
-      - uses: actions/checkout@v2
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Build for Lighthouse & serve locally
-        run: PUBLIC_URL=/ npm run build && (npm run serve&)
-
-      - name: Run Lighthouse
-        uses: foo-software/lighthouse-check-action@master
-        id: lighthouseCheck
-        with:
-          urls: "http://127.0.0.1:3000"
-          emulatedFormFactor: "desktop"
-      - name: Handle Lighthouse Check results
-        uses: foo-software/lighthouse-check-status-action@master
-        with:
-          lighthouseCheckResults: ${{ steps.lighthouseCheck.outputs.lighthouseCheckResults }}
-          minAccessibilityScore: "90"
-          minBestPracticesScore: "90"
-          minPerformanceScore: "90"
-          minSeoScore: "90"
-
   visual-regression:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Removed this check from the pipeline in order to avoid too many false
negatives. The `foo-software/lighthouse-check-action@master` action that
was used was not reliable when compared to simply running Lighthouse in
the browser and would inconsistently fail with different results each
time, resulting in a game of run checks > fail checks > rerun checks >
pass > done.